### PR TITLE
Fixed Autoplay issue

### DIFF
--- a/src/render_yt_item.sql
+++ b/src/render_yt_item.sql
@@ -38,7 +38,7 @@ begin
     );
   end if;
   
-  if l_autoplay = 'Y' then append_opt('autoplay','N'); end if;
+  if l_autoplay = 'Y' then append_opt('autoplay','1'); end if;
   if l_related = 'N' then append_opt('rel','0'); end if;
   if l_start is not null then append_opt('start',l_start); end if;
   if l_end is not null then append_opt('end',l_end); end if;


### PR DESCRIPTION
If Autoplay was turned on ('Y') then set the URL to autoplay=1, because that's the correct value. Not 'N'. See http://stackoverflow.com/questions/7281765/youtube-iframe-embed-auto-play